### PR TITLE
Switch docker-compose version to 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 
 networks:
   raidbot:


### PR DESCRIPTION
The normal use case is to run all of this on one machine. Compose Version 3 is meant for cluster deployments.

with this it should also be possible to deploy via portainer.io